### PR TITLE
Fix broken form validations on initial load

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -3,7 +3,7 @@ module ApplicationCable
     identified_by :session_id
 
     def connect
-      self.session_id = cookies.encrypted[:session_id]
+      self.session_id = request.session.id
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,2 @@
 class ApplicationController < ActionController::Base
-  before_action :set_action_cable_identifier
-
-  private
-
-  def set_action_cable_identifier
-    cookies.encrypted[:session_id] = session.id.to_s
-  end
 end


### PR DESCRIPTION
On initial load/request the `cookies.encrypted[:session_id]` was not set yet and therefore was nil. With that the form submission did not work on the intial load of the page. After a refresh it worked fine because the session cookie was set then. 

The OptimismChannel was initialized with a nil session id here:

https://github.com/leastbad/optimism-demo/blob/0510a16229a1646d330a8be5183159f794206497/app/channels/optimism_channel.rb#L1-L5


This PR now identifies the ActionCable connection by `request.session.id` instead of `cookies.encrypted[:session_id]`.

It looked like this:

```ruby
# Initial load
Started GET "/cable" for ::1 at 2020-10-30 02:12:45 +0100
Started GET "/cable/" [WebSocket] for ::1 at 2020-10-30 02:12:45 +0100
Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)
OptimismChannel is transmitting the subscription confirmation
OptimismChannel is streaming from optimism:

# After reload
Started GET "/cable" for ::1 at 2020-10-30 02:12:12 +0100
Started GET "/cable/" [WebSocket] for ::1 at 2020-10-30 02:12:12 +0100
Successfully upgraded to WebSocket (REQUEST_METHOD: GET, HTTP_CONNECTION: Upgrade, HTTP_UPGRADE: websocket)
Registered connection (53daef6f8b6413c938c34d0cc76f7ad2)
OptimismChannel is transmitting the subscription confirmation
OptimismChannel is streaming from optimism:53daef6f8b6413c938c34d0cc76f7ad2
```

With that change it now also streams on the initial load from the right OptimismChannel.